### PR TITLE
Vitals table now scrollable

### DIFF
--- a/Nutrition/public/javascripts/staticDDP.js
+++ b/Nutrition/public/javascripts/staticDDP.js
@@ -74,7 +74,7 @@ function dietCreateSide(cardBody, perc, side) {
 	var side = cardBody.append('div')
 			.attr('style', 'float:' + side + '; width: ' + perc)
 			.style("overflow", "auto")
-			.style("height", "100px");
+			.style("height", "75px"); //75px for 3 lines, can change to 100px for 4 lines
 	return side; 
 }
 

--- a/Nutrition/public/javascripts/vitalHandlers.js
+++ b/Nutrition/public/javascripts/vitalHandlers.js
@@ -60,7 +60,9 @@ function createTitleBurger(cardBody, title) {
 /* Generic create card sides/divisions */
 function createSide(cardBody, perc, side) {
 	var side = cardBody.append('div')
-							.attr('style', 'float:' + side + '; width: ' + perc);
+			.attr('style', 'float:' + side + '; width: ' + perc)
+			.style("overflow", "auto")
+			.style("height", "75px"); //75px for 3 lines, can change to 100px for 4 lines
 	return side;
 }
 

--- a/Nutrition/views/layouts/summary.handlebars
+++ b/Nutrition/views/layouts/summary.handlebars
@@ -84,7 +84,7 @@
 			<table id="dietNew" class="vtTable">
 				<tbody>
 					<tr> 
-						<th colspan="3" class="gdTableLabel trBottom">Diet Survery</th>
+						<th colspan="3" class="gdTableLabel trBottom">Diet Survey</th>
 						<th></th>
 						<th class="gdTableLabel trBottom">Grocery Purchase</th>
 						<th></th>


### PR DESCRIPTION
I set the table height for both at 75px, which shows 3 lines. The table should therefore be scrollable for the diet indicators and HBA1c which has 4 readings. You can change the table height to 100px in line 65 of vitalHandlers.js and line 77 of staticDDP.js